### PR TITLE
Generate log message without trailing newline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "import/prefer-default-export": 0,
     "import/newline-after-import": ["error", {"count": 2}],
     "arrow-body-style": 0,
-    "max-len": ["error", 120, 2, {"ignoreUrls": true, "ignoreComments": false}]
+    "max-len": ["error", 120, 2, {"ignoreUrls": true, "ignoreComments": false}],
+    "prefer-template": 0
   },
   "plugins": [
     "jest"

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,7 @@
     "import/prefer-default-export": 0,
     "import/newline-after-import": ["error", {"count": 2}],
     "arrow-body-style": 0,
-    "max-len": ["error", 120, 2, {"ignoreUrls": true, "ignoreComments": false}],
-    "prefer-template": 0
+    "max-len": ["error", 120, 2, {"ignoreUrls": true, "ignoreComments": false}]
   },
   "plugins": [
     "jest"

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,10 @@ const output = process.stdout
 
 /* eslint-disable key-spacing,space-in-parens,no-multi-spaces */
 module.exports = {
-  debug:   (msg, options) => { output.write(log.debug(  msg, options)) },
-  info:    (msg, options) => { output.write(log.info(   msg, options)) },
-  warning: (msg, options) => { output.write(log.warning(msg, options)) },
-  error:   (msg, options) => { output.write(log.error(  msg, options)) },
-  panic:   (msg, options) => { output.write(log.panic(  msg, options)); process.exit(1) },
+  debug:   (msg, options) => { output.write(log.debug(  msg, options) + '\n') },
+  info:    (msg, options) => { output.write(log.info(   msg, options) + '\n') },
+  warning: (msg, options) => { output.write(log.warning(msg, options) + '\n') },
+  error:   (msg, options) => { output.write(log.error(  msg, options) + '\n') },
+  panic:   (msg, options) => { output.write(log.panic(  msg, options) + '\n'); process.exit(1) },
 }
 /* eslint-enable */

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const log = require('./log-generator')
 
 const output = process.stdout
 
-/* eslint-disable key-spacing,space-in-parens,no-multi-spaces */
+/* eslint-disable key-spacing,space-in-parens,no-multi-spaces,prefer-template */
 module.exports = {
   debug:   (msg, options) => { output.write(log.debug(  msg, options) + '\n') },
   info:    (msg, options) => { output.write(log.info(   msg, options) + '\n') },

--- a/src/log-generator.js
+++ b/src/log-generator.js
@@ -20,7 +20,7 @@ function log(level, msg, options = {}) {
     result[key] = serialize(result[key])
   })
 
-  return `${circularJSON.stringify(result)}\n`
+  return `${circularJSON.stringify(result)}`
 }
 
 /* eslint-disable key-spacing,space-in-parens,no-multi-spaces */

--- a/src/log-generator.js
+++ b/src/log-generator.js
@@ -23,7 +23,7 @@ function log(level, msg, options = {}) {
   return `${circularJSON.stringify(result)}`
 }
 
-/* eslint-disable key-spacing,space-in-parens,no-multi-spaces */
+/* eslint-disable key-spacing,space-in-parens,no-multi-spaces,prefer-template */
 module.exports = {
   debug:   (msg, options) => log('debug',   msg, options),
   info:    (msg, options) => log('info',    msg, options),

--- a/src/log-generator.test.js
+++ b/src/log-generator.test.js
@@ -15,7 +15,7 @@ describe('log output', () => {
   const result = log.info('some output')
 
   test('should start with "{"', () => { expect(result[0]).toBe('{') })
-  test('should end with "}\\n"', () => { expect(result.substr(result.length - 2)).toBe('}\n') })
+  test('should end with "}"', () => { expect(result.substr(result.length - 1)).toBe('}') })
   test('should be parsable JSON', () => { expect(JSON.parse(result)).toBeTruthy() })
 })
 


### PR DESCRIPTION
### Problem

Utilizing the internal module `log-generator`s functions gives a trailing newline. This makes it not so nice to use for external usage, since each log output contains a trailing newline.


### Solution

The newline is add in the 'output.write()' command instead in the log-generator functions.

So
```
var gen = require('wrapp-log/src/log-generator')
console.log(logGen.info('Message').trim())
```
can now be
```
var gen = require('wrapp-log/src/log-generator')
console.log(logGen.info('Message'))
```
with the same end result