### PR TITLE
Ordered output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ log.panic('Too much to handle')
 #### Output
 
 ```
-{"level":"info","msg":"Informal message","timestamp":"2017-06-07T14:02:40.759Z"}
-{"error":{"name":"Error","message":"Cannot handle the overload...","stack":[{"fileName":"/Users/wrapp/test-logging.js","lineNumber":6,"functionName":null,"typeName":"Object","methodName":null,"columnNumber":9,"native":false},{"fileName":"module.js","lineNumber":571,"functionName":"Module._compile","typeName":"Module","methodName":"_compile","columnNumber":32,"native":false},{"fileName":"module.js","lineNumber":580,"functionName":"Module._extensions..js","typeName":"Object","methodName":".js","columnNumber":10,"native":false},{"fileName":"module.js","lineNumber":488,"functionName":"Module.load","typeName":"Module","methodName":"load","columnNumber":32,"native":false},{"fileName":"module.js","lineNumber":447,"functionName":"tryModuleLoad","typeName":null,"methodName":null,"columnNumber":12,"native":false},{"fileName":"module.js","lineNumber":439,"functionName":"Module._load","typeName":"Function","methodName":"_load","columnNumber":3,"native":false},{"fileName":"module.js","lineNumber":605,"functionName":"Module.runMain","typeName":"Module","methodName":"runMain","columnNumber":10,"native":false},{"fileName":"bootstrap_node.js","lineNumber":427,"functionName":"run","typeName":null,"methodName":null,"columnNumber":7,"native":false},{"fileName":"bootstrap_node.js","lineNumber":151,"functionName":"startup","typeName":null,"methodName":null,"columnNumber":9,"native":false},{"fileName":"bootstrap_node.js","lineNumber":542,"functionName":null,"typeName":null,"methodName":null,"columnNumber":3,"native":false}]},"level":"error","msg":"Something seriously wrong","timestamp":"2017-06-07T14:02:40.760Z"}
-{"level":"panic","msg":"Too much to handle","timestamp":"2017-06-07T14:02:40.762Z"}
+{"level":"info","timestamp":"2017-06-07T14:02:40.759Z","msg":"Informal message"}
+{"level":"error","timestamp":"2017-06-07T14:02:40.760Z","msg":"Something seriously wrong","error":{"name":"Error","message":"Cannot handle the overload...","stack":[{"fileName":"/Users/wrapp/test-logging.js","lineNumber":6,"functionName":null,"typeName":"Object","methodName":null,"columnNumber":9,"native":false},{"fileName":"module.js","lineNumber":571,"functionName":"Module._compile","typeName":"Module","methodName":"_compile","columnNumber":32,"native":false},{"fileName":"module.js","lineNumber":580,"functionName":"Module._extensions..js","typeName":"Object","methodName":".js","columnNumber":10,"native":false},{"fileName":"module.js","lineNumber":488,"functionName":"Module.load","typeName":"Module","methodName":"load","columnNumber":32,"native":false},{"fileName":"module.js","lineNumber":447,"functionName":"tryModuleLoad","typeName":null,"methodName":null,"columnNumber":12,"native":false},{"fileName":"module.js","lineNumber":439,"functionName":"Module._load","typeName":"Function","methodName":"_load","columnNumber":3,"native":false},{"fileName":"module.js","lineNumber":605,"functionName":"Module.runMain","typeName":"Module","methodName":"runMain","columnNumber":10,"native":false},{"fileName":"bootstrap_node.js","lineNumber":427,"functionName":"run","typeName":null,"methodName":null,"columnNumber":7,"native":false},{"fileName":"bootstrap_node.js","lineNumber":151,"functionName":"startup","typeName":null,"methodName":null,"columnNumber":9,"native":false},{"fileName":"bootstrap_node.js","lineNumber":542,"functionName":null,"typeName":null,"methodName":null,"columnNumber":3,"native":false}]}}
+{"level":"panic","timestamp":"2017-06-07T14:02:40.762Z","msg":"Too much to handle"}
 ```
 
 [Exited with code 1]
@@ -74,14 +74,18 @@ Each log message is on one and the same line and a line break `\n` is added afte
 The log output will look like the example below, but on one line only.
 Any additional properties will be added.
 
+For the `service` attribute to be automatically added to each log line the environment variable `SERVICE_NAME` must be set. If not set, the attribute will not be serialized.
+
 Errors are serialized to some extent (message, name and any attacked properties), and the error stack trace uses npm module [stack-trace](https://www.npmjs.com/package/stack-trace)
+
+The multiline format below is to show the order of data being outputted. Each actual log message will be serialized on one and the same line.  
 
 ```
 {
-  "level": "<debug|info|warning|error|panic>",
-  "msg": "<log text>",
   "service":"<service name>",
+  "level": "<debug|info|warning|error|panic>",
   "timestamp": "<timestamp>",
+  "msg": "<log text>",
   ["additional_properties": "some text| 123 | {\"deep\":\"stuff\"}"]
 }
 ```

--- a/src/log-generator.js
+++ b/src/log-generator.js
@@ -5,12 +5,12 @@ const circularJSON = require('circular-json')
 const illegalProperties = ['hostname']
 
 function log(level, msg, options = {}) {
-  const result = Object.assign({}, options, {
-    level,
-    msg,
+  const result = Object.assign({}, {
     service: process.env.SERVICE_NAME,
+    level,
     timestamp: new Date(),
-  })
+    msg,
+  }, options)
 
   // Delete all illegal properties
   illegalProperties.forEach((key) => { delete result[key] })

--- a/src/log-generator.test.js
+++ b/src/log-generator.test.js
@@ -36,6 +36,22 @@ describe('log output should never contain illegal property:', () => {
   test('"hostname"', () => { expect(result.hostname).toBeUndefined() })
 })
 
+describe('log output should output mandatory data', () => {
+  const result = log.info('msg')
+
+  test('"in order"', () => {
+    expect(result).toMatch(/{"service":".*","level":"info","timestamp":".*","msg":"msg"}/)
+  })
+})
+
+describe('log output with additional attributes should output data', () => {
+  const result = log.info('msg', { data: { sub: 1, x: 'x' } })
+
+  test('"with mandatory data order first and then additional attributes"', () => {
+    expect(result).toMatch(/{"service":".*","level":"info","timestamp":".*","msg":"msg","data":{"sub":1,"x":"x"}}/)
+  })
+})
+
 describe('testing all different log levels', () => {
   /* eslint-disable no-multi-spaces,space-in-parens */
   test('debug',   () => expect(JSON.parse(log.debug(''  ))).toHaveProperty('level', 'debug'))

--- a/src/log-generator.test.js
+++ b/src/log-generator.test.js
@@ -52,6 +52,14 @@ describe('log output with additional attributes should output data', () => {
   })
 })
 
+describe('all mandatory data can be overwritten in options object but stay in order:', () => {
+  const result = log.info('x', { msg: 'msg', level: 'level', service: 'service', timestamp: 'timestamp' })
+
+  test('"with mandatory data order first and then additional attributes"', () => {
+    expect(result).toMatch(/{"service":"service","level":"level","timestamp":"timestamp","msg":"msg"}/)
+  })
+})
+
 describe('testing all different log levels', () => {
   /* eslint-disable no-multi-spaces,space-in-parens */
   test('debug',   () => expect(JSON.parse(log.debug(''  ))).toHaveProperty('level', 'debug'))


### PR DESCRIPTION
### Problem

With long logs (for example error logging with stacktraces), the mandatory fields are being serialized in the end of the log line. That makes it hard find the `msg`, `level` etc in the log output.

Solves issue #5 


### Solution

Make sure the mandatory (standard) log attributes are always first and in specific order.

The order is: `[service], level, timestamp, msg, [...additional attributes]`